### PR TITLE
chore: Adicionando volume ao container pg e container pgadmin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Custom
+postgres-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,14 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: docker
       POSTGRES_DB: nest-unisinos
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4
+    ports:
+      - 15432:80
+    environment:
+      PGADMIN_DEFAULT_EMAIL: nest@matriculas.com
+      PGADMIN_DEFAULT_PASSWORD: nest


### PR DESCRIPTION
- Adicionando volume ao container do postgres, para poder manter os dados, mesmo após algum prune do container
- Adicionado folder do volume ao gitignore
- Adicionando container pgadmin ao docker-compose pra facilitar observação das tabelas/dados gerados